### PR TITLE
Interaction handlers

### DIFF
--- a/change/@fluentui-react-teams-c102f87a-9cad-4a88-8d38-7f1403a08030.json
+++ b/change/@fluentui-react-teams-c102f87a-9cad-4a88-8d38-7f1403a08030.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adjust interaction ontology",
+  "packageName": "@fluentui/react-teams",
+  "email": "v-wishow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teams-c102f87a-9cad-4a88-8d38-7f1403a08030.json
+++ b/change/@fluentui-react-teams-c102f87a-9cad-4a88-8d38-7f1403a08030.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Adjust interaction ontology",
+  "comment": "This PR adds the onInteraction optional handler to interactive HVCs, which allows developers to handle user interactions in the HVCs in a way that is forward-compatible with a JSON API.\n\nAll HVCs will call onInteraction for interactions designed for developer response with a monolithic object payload.",
   "packageName": "@fluentui/react-teams",
   "email": "v-wishow@microsoft.com",
   "dependentChangeType": "patch"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
-    "@fluentui/example-data": "^8.0.0-beta.0",
     "@fluentui/react-icons-northstar": "^0.51.3",
     "@fluentui/react-northstar": "^0.51.3",
     "@storybook/addon-a11y": "^5.3.19",
@@ -66,7 +65,7 @@
     "eslint-plugin-jsx-a11y": "6.3.0",
     "eslint-plugin-react": "7.20.0",
     "eslint-plugin-react-hooks": "4.0.0",
-    "faker": "Marak/faker.js",
+    "faker": "thure/faker.js#v5.1.1",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^5.0.7",
     "html-webpack-plugin": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-jsx-a11y": "6.3.0",
     "eslint-plugin-react": "7.20.0",
     "eslint-plugin-react-hooks": "4.0.0",
-    "faker": "thure/faker.js#v5.1.1",
+    "faker": "thure/faker.js#v5.1.2",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^5.0.7",
     "html-webpack-plugin": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-teams",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "description": "Teams components in the Fluent UI design language written in React",
   "repository": "https://github.com/OfficeDev/microsoft-teams-ui-component-library.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
+    "@fluentui/example-data": "^8.0.0-beta.0",
     "@fluentui/react-icons-northstar": "^0.51.3",
     "@fluentui/react-northstar": "^0.51.3",
     "@storybook/addon-a11y": "^5.3.19",

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -82,13 +82,28 @@ const defaultBoardItemCardLayout: IBoardItemCardLayout = {
   overflowPosition: "footer",
 };
 
+interface IBoardInteractionUpdateLanes {
+  event: "update";
+  target: "lanes";
+  lanes: TBoardLanes;
+}
+
+interface IBoardInteractionUpdateItems {
+  event: "update";
+  target: "items";
+  items: IPreparedBoardItems;
+}
+
+export type TBoardInteraction =
+  | IBoardInteractionUpdateLanes
+  | IBoardInteractionUpdateItems;
+
 export interface IBoardProps {
   users: TUsers;
   lanes: TBoardLanes;
   items: TBoardItems;
   boardItemCardLayout?: IBoardItemCardLayout;
-  onUpdateItems?: (items: IPreparedBoardItems) => void;
-  onUpdateLanes?: (lanes: TBoardLanes) => void;
+  onInteraction?: (interaction: TBoardInteraction) => void;
 }
 
 interface IBoardStandaloneProps {
@@ -481,12 +496,14 @@ export const Board = (props: IBoardProps) => {
   const [addingLane, setAddingLane] = useState<boolean>(false);
 
   const setArrangedLanes = (lanes: TBoardLanes) => {
-    if (props.onUpdateLanes) props.onUpdateLanes(lanes);
+    if (props.onInteraction)
+      props.onInteraction({ event: "update", target: "lanes", lanes });
     return setStateArrangedLanes(lanes as SetStateAction<TBoardLanes>);
   };
 
   const setArrangedItems = (items: IPreparedBoardItems) => {
-    if (props.onUpdateItems) props.onUpdateItems(items);
+    if (props.onInteraction)
+      props.onInteraction({ event: "update", target: "items", items });
     return setStateArrangedItems(items as SetStateAction<IPreparedBoardItems>);
   };
 

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -87,6 +87,8 @@ export interface IBoardProps {
   lanes: TBoardLanes;
   items: TBoardItems;
   boardItemCardLayout?: IBoardItemCardLayout;
+  onUpdateItems?: (items: IPreparedBoardItems) => void;
+  onUpdateLanes?: (lanes: TBoardLanes) => void;
 }
 
 interface IBoardStandaloneProps {
@@ -468,13 +470,25 @@ const BoardStandalone = (props: IBoardStandaloneProps) => {
 };
 
 export const Board = (props: IBoardProps) => {
-  const [arrangedLanes, setArrangedLanes] = useState<TBoardLanes>(props.lanes);
+  const [arrangedLanes, setStateArrangedLanes] = useState<TBoardLanes>(
+    props.lanes
+  );
 
-  const [arrangedItems, setArrangedItems] = useState<IPreparedBoardItems>(
+  const [arrangedItems, setStateArrangedItems] = useState<IPreparedBoardItems>(
     prepareBoardItems(props.items, props.lanes)
   );
 
   const [addingLane, setAddingLane] = useState<boolean>(false);
+
+  const setArrangedLanes = (lanes: TBoardLanes) => {
+    if (props.onUpdateLanes) props.onUpdateLanes(lanes);
+    return setStateArrangedLanes(lanes as SetStateAction<TBoardLanes>);
+  };
+
+  const setArrangedItems = (items: IPreparedBoardItems) => {
+    if (props.onUpdateItems) props.onUpdateItems(items);
+    return setStateArrangedItems(items as SetStateAction<IPreparedBoardItems>);
+  };
 
   return (
     <FluentUIThemeConsumer
@@ -509,10 +523,14 @@ export const Board = (props: IBoardProps) => {
                   rtl,
                   arrangedLanes,
                   arrangedItems,
-                  setArrangedItems,
+                  setArrangedItems: setArrangedItems as Dispatch<
+                    SetStateAction<IPreparedBoardItems>
+                  >,
                   addingLane,
                   setAddingLane,
-                  setArrangedLanes,
+                  setArrangedLanes: setArrangedLanes as Dispatch<
+                    SetStateAction<TBoardLanes>
+                  >,
                 }}
                 {...pick(props, ["users", "boardItemCardLayout"])}
               />

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -526,12 +526,12 @@ export const Board = (props: IBoardProps) => {
                     a1: {
                       icon: "Add",
                       title: t["add lane"],
-                      __internal_callback__: "add_column",
+                      subject: "add_column",
                     },
                   },
                 }}
-                __internal_callbacks__={{
-                  add_column: () => setAddingLane(true),
+                onInteraction={({ subject }) => {
+                  if (subject === "add_column") setAddingLane(true);
                 }}
               />
               <BoardStandalone

--- a/src/components/Board/BoardItemDialog.tsx
+++ b/src/components/Board/BoardItemDialog.tsx
@@ -123,58 +123,56 @@ export const BoardItemDialog = ({
             return t["cancel"];
         }
       })()}
-      __internal_callbacks__={{
-        submit: (_e, formState) => {
-          if (!formState) return;
-          const boardItem = Object.keys(formState).reduce(
-            (
-              boardItem: {
-                [boardItemPropKey: string]: any;
-              },
-              inputId
-            ) => {
-              const [_prefix, boardItemProperty] = inputId.split("__");
-              const value = formState[inputId];
-              if (value) boardItem[boardItemProperty] = value;
-              return boardItem;
+      onInteraction={({ formState }) => {
+        if (!formState) return;
+        const boardItem = Object.keys(formState).reduce(
+          (
+            boardItem: {
+              [boardItemPropKey: string]: any;
             },
-            (function () {
-              switch (action) {
-                case BoardItemDialogAction.Create:
-                  return {
-                    order: -1,
-                    itemKey: uniqueId("nbi"),
-                  };
-                case BoardItemDialogAction.Edit:
-                  return cloneDeep(initialState);
-              }
-            })()
-          );
-          switch (action) {
-            case BoardItemDialogAction.Create:
+            inputId
+          ) => {
+            const [_prefix, boardItemProperty] = inputId.split("__");
+            const value = formState[inputId];
+            if (value) boardItem[boardItemProperty] = value;
+            return boardItem;
+          },
+          (function () {
+            switch (action) {
+              case BoardItemDialogAction.Create:
+                return {
+                  order: -1,
+                  itemKey: uniqueId("nbi"),
+                };
+              case BoardItemDialogAction.Edit:
+                return cloneDeep(initialState);
+            }
+          })()
+        );
+        switch (action) {
+          case BoardItemDialogAction.Create:
+            arrangedItems[boardItem.lane as string].push(
+              (boardItem as unknown) as IPreparedBoardItem
+            );
+            break;
+          case BoardItemDialogAction.Edit:
+            const fromPos = arrangedItems[
+              initialState.lane as string
+            ].findIndex(
+              (laneItem) => laneItem.itemKey === initialState.itemKey!
+            );
+            if (boardItem.lane !== initialState.lane) {
+              arrangedItems[initialState.lane as string].splice(fromPos, 1);
               arrangedItems[boardItem.lane as string].push(
-                (boardItem as unknown) as IPreparedBoardItem
+                boardItem as IPreparedBoardItem
               );
-              break;
-            case BoardItemDialogAction.Edit:
-              const fromPos = arrangedItems[
-                initialState.lane as string
-              ].findIndex(
-                (laneItem) => laneItem.itemKey === initialState.itemKey!
-              );
-              if (boardItem.lane !== initialState.lane) {
-                arrangedItems[initialState.lane as string].splice(fromPos, 1);
-                arrangedItems[boardItem.lane as string].push(
-                  boardItem as IPreparedBoardItem
-                );
-              } else {
-                arrangedItems[boardItem.lane as string][
-                  fromPos
-                ] = boardItem as IPreparedBoardItem;
-              }
-          }
-          setArrangedItems(cloneDeep(arrangedItems));
-        },
+            } else {
+              arrangedItems[boardItem.lane as string][
+                fromPos
+              ] = boardItem as IPreparedBoardItem;
+            }
+        }
+        setArrangedItems(cloneDeep(arrangedItems));
       }}
     />
   );

--- a/src/components/Communication/Communication.tsx
+++ b/src/components/Communication/Communication.tsx
@@ -32,7 +32,11 @@ import {
   WELCOME_MESSAGE,
 } from "./CommunicationOptions";
 
-export function Communication({ option, fields }: TCommunication) {
+export function Communication({
+  option,
+  fields,
+  onInteraction,
+}: TCommunication) {
   const [componentTheme, setComponentTheme] = React.useState<TeamsTheme>(
     TeamsTheme.Default
   );
@@ -85,6 +89,20 @@ export function Communication({ option, fields }: TCommunication) {
       setSafeImageUrl(themedImage[componentTheme]);
     });
   }
+
+  const onClick = onInteraction
+    ? function (target: string) {
+        return function () {
+          return onInteraction({
+            event: "click",
+            target,
+          });
+        };
+      }
+    : function () {
+        return function () {};
+      };
+
   return (
     <FluentUIThemeConsumer
       render={(globalTheme) => {
@@ -187,7 +205,7 @@ export function Communication({ option, fields }: TCommunication) {
                     {actions.primary && (
                       <Button
                         content={actions.primary.label}
-                        onClick={actions.primary.action}
+                        onClick={onClick(actions.primary.target)}
                         aria-label={actions.primary.label}
                         styles={{ width: "100%" }}
                         primary
@@ -196,7 +214,7 @@ export function Communication({ option, fields }: TCommunication) {
                     {actions.secondary && (
                       <Button
                         content={actions.secondary.label}
-                        onClick={actions.secondary.action}
+                        onClick={onClick(actions.secondary.target)}
                         aria-label={actions.secondary.label}
                         styles={{ width: "100%" }}
                       />
@@ -205,7 +223,7 @@ export function Communication({ option, fields }: TCommunication) {
                       <Button text primary>
                         <Text
                           content={actions.tertiary.label}
-                          onClick={actions.tertiary.action}
+                          onClick={onClick(actions.tertiary.target)}
                           weight="light"
                         />
                       </Button>

--- a/src/components/Communication/Communication.tsx
+++ b/src/components/Communication/Communication.tsx
@@ -91,17 +91,14 @@ export function Communication({
   }
 
   const onClick = onInteraction
-    ? function (target: string) {
-        return function () {
-          return onInteraction({
+    ? (target: string) => ({
+        onClick: () =>
+          onInteraction({
             event: "click",
             target,
-          });
-        };
-      }
-    : function () {
-        return function () {};
-      };
+          }),
+      })
+    : () => ({});
 
   return (
     <FluentUIThemeConsumer
@@ -205,26 +202,26 @@ export function Communication({
                     {actions.primary && (
                       <Button
                         content={actions.primary.label}
-                        onClick={onClick(actions.primary.target)}
                         aria-label={actions.primary.label}
                         styles={{ width: "100%" }}
                         primary
+                        {...onClick(actions.primary.target)}
                       />
                     )}
                     {actions.secondary && (
                       <Button
                         content={actions.secondary.label}
-                        onClick={onClick(actions.secondary.target)}
                         aria-label={actions.secondary.label}
                         styles={{ width: "100%" }}
+                        {...onClick(actions.secondary.target)}
                       />
                     )}
                     {actions.tertiary && (
                       <Button text primary>
                         <Text
                           content={actions.tertiary.label}
-                          onClick={onClick(actions.tertiary.target)}
                           weight="light"
+                          {...onClick(actions.tertiary.target)}
                         />
                       </Button>
                     )}

--- a/src/components/Communication/CommunicationOptions/Default.tsx
+++ b/src/components/Communication/CommunicationOptions/Default.tsx
@@ -8,15 +8,15 @@ export const DEFAULT_MESSAGE = {
   actions: {
     primary: {
       label: "Primary action",
-      action: () => alert("Primary action called"),
+      target: "primary",
     },
     secondary: {
       label: "Secondary action",
-      action: () => alert("Secondary action called"),
+      target: "secondary",
     },
     tertiary: {
       label: "Tertiary action",
-      action: () => alert("Tertiary action called"),
+      target: "tertiary",
     },
   },
 };

--- a/src/components/Communication/CommunicationOptions/Error.tsx
+++ b/src/components/Communication/CommunicationOptions/Error.tsx
@@ -8,11 +8,11 @@ export const ERROR_MESSAGE = {
   actions: {
     primary: {
       label: "Refresh",
-      action: () => alert("Refresh action called"),
+      target: "refresh",
     },
     tertiary: {
       label: "Start over",
-      action: () => alert("Start over action called"),
+      target: "start-over",
     },
   },
 };

--- a/src/components/Communication/CommunicationOptions/Hello.tsx
+++ b/src/components/Communication/CommunicationOptions/Hello.tsx
@@ -7,11 +7,11 @@ export const HELLO_MESSAGE = {
   actions: {
     primary: {
       label: "Create a board",
-      action: () => alert("Create a board action called"),
+      target: "create",
     },
     secondary: {
       label: "Find an existing board",
-      action: () => alert("Find an existing board action called"),
+      target: "find",
     },
   },
 };

--- a/src/components/Communication/CommunicationOptions/Thanks.tsx
+++ b/src/components/Communication/CommunicationOptions/Thanks.tsx
@@ -7,11 +7,11 @@ export const THANKS_MESSAGE = {
   actions: {
     primary: {
       label: "Start the next challenge",
-      action: () => alert("Next challenge action called"),
+      target: "start-next",
     },
     secondary: {
       label: "Celebrate with your colleagues",
-      action: () => alert("Celebrate action called"),
+      target: "celebrate",
     },
   },
 };

--- a/src/components/Communication/CommunicationOptions/Welcome.tsx
+++ b/src/components/Communication/CommunicationOptions/Welcome.tsx
@@ -4,15 +4,15 @@ export const WELCOME_MESSAGE = {
   actions: {
     primary: {
       label: "Sign In",
-      action: () => alert("Sign In action called"),
+      target: "sign-in",
     },
     secondary: {
       label: "Sign Up",
-      action: () => alert("Sign Up action called"),
+      target: "register",
     },
     tertiary: {
       label: "Learn more about {{appName}}",
-      action: () => alert("Learn more action called"),
+      target: "info:{{appName}}",
     },
   },
 };

--- a/src/components/Communication/CommunicationTypes.ts
+++ b/src/components/Communication/CommunicationTypes.ts
@@ -9,9 +9,22 @@ export enum CommunicationOptions {
   Thanks = "thanks",
 }
 
+export type TCommunicationInteraction = {
+  event: "click";
+  target: string;
+};
+
 export type TCommunication =
-  | { option?: CommunicationOptions; fields: TCommunicationFields }
-  | { option: CommunicationOptions; fields?: TCommunicationFields };
+  | {
+      option?: CommunicationOptions;
+      fields: TCommunicationFields;
+      onInteraction?: (interaction: TCommunicationInteraction) => void;
+    }
+  | {
+      option: CommunicationOptions;
+      fields?: TCommunicationFields;
+      onInteraction?: (interaction: TCommunicationInteraction) => void;
+    };
 
 export type TCommunicationFields =
   | ICommunicationFields
@@ -67,5 +80,5 @@ export type CommunicationActions =
 
 export interface ICommunicationAction {
   label: string;
-  action: () => void;
+  target: string;
 }

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -20,7 +20,7 @@ interface IDashboard {
 const toolbarConfig = {
   actionGroups: {
     h1: {
-      b1: { title: "Edit dashboard", icon: "Edit" },
+      edit: { title: "Edit dashboard", icon: "Edit" },
     },
   },
   filters: [],

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -41,7 +41,7 @@ import getBreakpoints, {
   TSortable,
 } from "./tableBreakpoints";
 
-import { TActionsWithoutSubjects, actionKey } from "../..";
+import { TActions, actionKey } from "../..";
 import { TeamsTheme } from "../../themes";
 import { TTranslations } from "../../translations";
 
@@ -52,13 +52,15 @@ type sortOrder = [columnKey | "__rowKey__", "asc" | "desc"];
 export type TSelected = Set<rowKey>;
 
 export interface IRow {
-  [columnKey: string]: string | TActionsWithoutSubjects | undefined;
-  actions?: TActionsWithoutSubjects;
+  [columnKey: string]: string | TActions | undefined;
+  actions?: TActions;
 }
 
 export type TTableInteraction = {
   event: "click";
-  target: ["table", rowKey, actionKey];
+  target: "table";
+  subject: rowKey | rowKey[];
+  action: actionKey;
 };
 
 export interface ITableProps extends PropsOfElement<"div"> {
@@ -472,11 +474,9 @@ export const Table = (props: ITableProps) => {
                                                       onClick: () =>
                                                         props.onInteraction!({
                                                           event: "click",
-                                                          target: [
-                                                            "table",
-                                                            rowKey,
-                                                            rowActionKey,
-                                                          ],
+                                                          target: "table",
+                                                          subject: rowKey,
+                                                          action: rowActionKey,
                                                         }),
                                                     }),
                                                   };
@@ -499,11 +499,9 @@ export const Table = (props: ITableProps) => {
                                                       onClick: () =>
                                                         props.onInteraction!({
                                                           event: "click",
-                                                          target: [
-                                                            "table",
-                                                            rowKey,
-                                                            rowActionKey,
-                                                          ],
+                                                          target: "table",
+                                                          subject: rowKey,
+                                                          action: rowActionKey,
                                                         }),
                                                     }),
                                                   };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -41,7 +41,7 @@ import getBreakpoints, {
   TSortable,
 } from "./tableBreakpoints";
 
-import { TActions } from "../..";
+import { TActionsWithoutSubjects, actionKey } from "../..";
 import { TeamsTheme } from "../../themes";
 import { TTranslations } from "../../translations";
 
@@ -52,9 +52,14 @@ type sortOrder = [columnKey | "__rowKey__", "asc" | "desc"];
 export type TSelected = Set<rowKey>;
 
 export interface IRow {
-  [columnKey: string]: string | TActions | undefined;
-  actions?: TActions;
+  [columnKey: string]: string | TActionsWithoutSubjects | undefined;
+  actions?: TActionsWithoutSubjects;
 }
+
+export type TTableInteraction = {
+  event: "click";
+  target: ["table", rowKey, actionKey];
+};
 
 export interface ITableProps extends PropsOfElement<"div"> {
   columns: { [columnKey: string]: IColumn };
@@ -64,6 +69,7 @@ export interface ITableProps extends PropsOfElement<"div"> {
   onSelectedChange?: (selected: TSelected) => TSelected;
   findQuery?: string;
   filterBy?: (row: IRow) => boolean;
+  onInteraction?: (interaction: TTableInteraction) => void;
 }
 
 interface ISortOrderIndicatorProps {
@@ -462,6 +468,17 @@ export const Table = (props: ITableProps) => {
                                                       />
                                                     ),
                                                     content: "Details",
+                                                    ...(props.onInteraction && {
+                                                      onClick: () =>
+                                                        props.onInteraction!({
+                                                          event: "click",
+                                                          target: [
+                                                            "table",
+                                                            rowKey,
+                                                            rowActionKey,
+                                                          ],
+                                                        }),
+                                                    }),
                                                   };
                                                 default:
                                                   return {
@@ -478,6 +495,17 @@ export const Table = (props: ITableProps) => {
                                                     content: row.actions![
                                                       rowActionKey
                                                     ].title,
+                                                    ...(props.onInteraction && {
+                                                      onClick: () =>
+                                                        props.onInteraction!({
+                                                          event: "click",
+                                                          target: [
+                                                            "table",
+                                                            rowKey,
+                                                            rowActionKey,
+                                                          ],
+                                                        }),
+                                                    }),
                                                   };
                                               }
                                             }

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -7,7 +7,6 @@ import {
   ButtonContent,
   ObjectShorthandCollection,
   Position,
-  PropsOfElement,
   ProviderConsumer as FluentUIThemeConsumer,
   ShorthandCollection,
   Toolbar as FluentUIToolbar,
@@ -23,7 +22,7 @@ import { SiteVariablesPrepared } from "@fluentui/styles";
 import Icon from "../../lib/Icon";
 import { TeamsTheme } from "../../themes";
 
-import { TAction, TActions, WithOptionalInternalCallbacks } from "../..";
+import { actionKey, TAction, TActions } from "../..";
 
 import { ToolbarFilter } from "./ToolbarFilter";
 import { ToolbarFind } from "./ToolbarFind";
@@ -35,20 +34,24 @@ type TToolbarItems = ShorthandCollection<
 >;
 
 export type TActionGroups = {
-  [slug: string]: TActions;
+  [actionKey: string]: TActions;
 };
 
 export type TFilters = ObjectShorthandCollection<TreeItemProps, never>;
 
-export interface IToolbarProps
-  extends PropsOfElement<"div">,
-    WithOptionalInternalCallbacks<ToolbarItemProps> {
+export type TToolbarInteraction = {
+  event: "click";
+  target: ["toolbar", string | string[], actionKey];
+};
+
+export interface IToolbarProps {
   actionGroups: TActionGroups;
   filters?: TFilters;
   find?: boolean;
   filtersSingleSelect?: boolean;
   onSelectedFiltersChange?: (selectedFilters: string[]) => string[];
   onFindQueryChange?: (findQuery: string) => string;
+  onInteraction?: (interaction: TToolbarInteraction) => void;
 }
 
 export type TToolbarLayout = "compact" | "verbose";
@@ -87,9 +90,9 @@ function flattenedActions(actionGroups: TActionGroups): TActions {
   return Object.keys(actionGroups).reduce(
     (acc_i: TActions, actionGroupSlug: string) => {
       const actionGroup = actionGroups[actionGroupSlug];
-      return Object.keys(actionGroup).reduce((acc_j, actionSlug) => {
-        const action = actionGroup[actionSlug];
-        acc_j[`${actionGroupSlug}${slugSeparator}${actionSlug}`] = action;
+      return Object.keys(actionGroup).reduce((acc_j, actionKey) => {
+        const action = actionGroup[actionKey];
+        acc_j[`${actionGroupSlug}${slugSeparator}${actionKey}`] = action;
         return acc_j;
       }, acc_i);
     },
@@ -98,14 +101,14 @@ function flattenedActions(actionGroups: TActionGroups): TActions {
 }
 
 function needsSeparator(
-  actionSlug: string,
+  actionKey: string,
   index: number,
-  actionSlugs: string[]
+  actionKeys: string[]
 ): boolean {
   return index === 0
     ? false
-    : actionSlugs[index - 1]?.split(slugSeparator)[0] !==
-        actionSlug.split(slugSeparator)[0];
+    : actionKeys[index - 1]?.split(slugSeparator)[0] !==
+        actionKey.split(slugSeparator)[0];
 }
 
 interface IInFlowToolbarItemProps {
@@ -181,16 +184,11 @@ export const Toolbar = (props: IToolbarProps) => {
   });
 
   const inFlowToolbarItems: TToolbarItems = Object.keys(allActions).reduce(
-    (acc: TToolbarItems, actionSlug, index, actionSlugs) => {
-      const action = allActions[actionSlug];
-
-      const onClick =
-        action.__internal_callback__ &&
-        props.__internal_callbacks__ &&
-        props.__internal_callbacks__[action.__internal_callback__];
+    (acc: TToolbarItems, actionKey, index, actionKeys) => {
+      const action = allActions[actionKey];
 
       acc.push({
-        key: actionSlug,
+        key: actionKey,
         children: <InFlowToolbarItem action={action} layout={layout} />,
         title: action.title,
         "aria-label": action.title,
@@ -203,9 +201,15 @@ export const Toolbar = (props: IToolbarProps) => {
           justifyContent: "center",
           alignItems: "center",
         },
-        ...(onClick ? { onClick } : {}),
+        ...(props.onInteraction && {
+          onClick: () =>
+            props.onInteraction!({
+              event: "click",
+              target: ["toolbar", action.subject, actionKey],
+            }),
+        }),
       });
-      if (needsSeparator(actionSlug, index, actionSlugs))
+      if (needsSeparator(actionKey, index, actionKeys))
         acc.push({
           key: `divider${slugSeparator}${index}`,
           kind: "divider",
@@ -216,17 +220,24 @@ export const Toolbar = (props: IToolbarProps) => {
   );
 
   const overflowToolbarItems: TToolbarItems = Object.keys(allActions).reduce(
-    (acc: TToolbarItems, actionSlug, index, actionSlugs) => {
-      const action = allActions[actionSlug];
+    (acc: TToolbarItems, actionKey, index, actionKeys) => {
+      const action = allActions[actionKey];
       acc.push({
-        key: actionSlug,
+        key: actionKey,
         content: action.title,
         icon: <Icon icon={action.icon} />,
         title: action.title,
         "aria-label": action.title,
         styles: { padding: ".375rem .5rem" },
+        ...(props.onInteraction && {
+          onClick: () =>
+            props.onInteraction!({
+              event: "click",
+              target: ["toolbar", action.subject, actionKey],
+            }),
+        }),
       });
-      if (needsSeparator(actionSlug, index, actionSlugs))
+      if (needsSeparator(actionKey, index, actionKeys))
         acc.push({
           key: `divider${slugSeparator}${index}`,
           kind: "divider",

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -253,7 +253,6 @@ export const Toolbar = (props: IToolbarProps) => {
               elevation: colorScheme.elevations[16],
             })}
             styles={{
-              width: "100vw",
               display: "flex",
               justifyContent: "space-between",
               padding: "0 1.25rem",

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -41,7 +41,9 @@ export type TFilters = ObjectShorthandCollection<TreeItemProps, never>;
 
 export type TToolbarInteraction = {
   event: "click";
-  target: ["toolbar", string | string[], actionKey];
+  target: "toolbar";
+  subject: string | string[] | null;
+  action: actionKey;
 };
 
 export interface IToolbarProps {
@@ -205,7 +207,9 @@ export const Toolbar = (props: IToolbarProps) => {
           onClick: () =>
             props.onInteraction!({
               event: "click",
-              target: ["toolbar", action.subject, actionKey],
+              target: "toolbar",
+              subject: action.subject || null,
+              action: actionKey.split("__").pop()!,
             }),
         }),
       });
@@ -233,7 +237,9 @@ export const Toolbar = (props: IToolbarProps) => {
           onClick: () =>
             props.onInteraction!({
               event: "click",
-              target: ["toolbar", action.subject, actionKey],
+              target: "toolbar",
+              action: actionKey.split("__").pop()!,
+              subject: action.subject || null,
             }),
         }),
       });

--- a/src/components/Toolbar/ToolbarTheme.tsx
+++ b/src/components/Toolbar/ToolbarTheme.tsx
@@ -145,7 +145,6 @@ export const ToolbarTheme = ({ globalTheme, children }: IToolbarThemeProps) => {
     <FluentUIThemeProvider
       theme={theme}
       styles={{
-        display: "grid",
         backgroundColor: theme.siteVariables?.colorScheme.default.background2,
       }}
     >

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,10 @@ export { HVCThemeProvider as Provider } from "./lib/withTheme";
 export { TeamsTheme as themeNames } from "./themes";
 
 export {
+  actionKey,
   TAction,
   TActions,
+  TActionsWithoutSubjects,
   TUser,
   TUsers,
   WithOptionalInternalCallbacks,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ export {
   actionKey,
   TAction,
   TActions,
-  TActionsWithoutSubjects,
   TUser,
   TUsers,
   WithOptionalInternalCallbacks,

--- a/src/stories/Board.stories.tsx
+++ b/src/stories/Board.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { object } from "@storybook/addon-knobs";
 import fakerEN from "faker/locale/en_US";
 import fakerFA from "faker/locale/fa";
-import { TestImages } from "@fluentui/example-data";
 import range from "lodash/range";
 import shuffle from "lodash/shuffle";
 
@@ -30,14 +29,7 @@ export const KitchenSink = () => {
     users: usersRange.reduce((acc: TUsers, i) => {
       acc[`u${i}`] = {
         name: fake("{{name.findName}}"),
-        ...(Math.random() > 0.33
-          ? {
-              image:
-                Math.random() > 0.5
-                  ? TestImages.personaFemale
-                  : TestImages.personaMale,
-            }
-          : {}),
+        ...(Math.random() > 0.33 ? { image: fakerEN.internet.avatar() } : {}),
       };
       return acc;
     }, {}),

--- a/src/stories/Board.stories.tsx
+++ b/src/stories/Board.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { object } from "@storybook/addon-knobs";
 import fakerEN from "faker/locale/en_US";
 import fakerFA from "faker/locale/fa";
+import { TestImages } from "@fluentui/example-data";
 import range from "lodash/range";
 import shuffle from "lodash/shuffle";
 
@@ -29,7 +30,14 @@ export const KitchenSink = () => {
     users: usersRange.reduce((acc: TUsers, i) => {
       acc[`u${i}`] = {
         name: fake("{{name.findName}}"),
-        ...(Math.random() > 0.33 ? { image: fakerEN.internet.avatar() } : {}),
+        ...(Math.random() > 0.33
+          ? {
+              image:
+                Math.random() > 0.5
+                  ? TestImages.personaFemale
+                  : TestImages.personaMale,
+            }
+          : {}),
       };
       return acc;
     }, {}),

--- a/src/stories/Board.stories.tsx
+++ b/src/stories/Board.stories.tsx
@@ -13,7 +13,7 @@ export default {
   component: Board,
 };
 
-const eventsFromNames = actions("onUpdateItems", "onUpdateLanes");
+const eventsFromNames = actions("onInteraction");
 
 const boardKnobGroupID = "Board";
 

--- a/src/stories/Board.stories.tsx
+++ b/src/stories/Board.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { object } from "@storybook/addon-knobs";
+import { actions } from "@storybook/addon-actions";
 import fakerEN from "faker/locale/en_US";
 import fakerFA from "faker/locale/fa";
 import range from "lodash/range";
@@ -11,6 +12,8 @@ export default {
   title: "UI Templates/Board",
   component: Board,
 };
+
+const eventsFromNames = actions("onUpdateItems", "onUpdateLanes");
 
 const boardKnobGroupID = "Board";
 
@@ -94,6 +97,7 @@ export const KitchenSink = () => {
   return (
     <Board
       {...object("Content", boardContent, boardKnobGroupID)}
+      {...eventsFromNames}
       boardItemCardLayout={object(
         "Board item card layout",
         boardItemCardLayout,

--- a/src/stories/Communication.stories.tsx
+++ b/src/stories/Communication.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { withKnobs, object } from "@storybook/addon-knobs";
+import { actions } from "@storybook/addon-actions";
 import { withA11y } from "@storybook/addon-a11y";
 
 import Communication, {
@@ -15,6 +16,8 @@ export default {
   decorators: [withKnobs, withA11y],
 };
 
+const eventsFromNames = actions("onInteraction");
+
 const communicationKnobGroupID = "Communication";
 
 /*
@@ -25,6 +28,7 @@ export const Default = () => {
   return (
     <Communication
       {...object("Configuration", defaultConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -37,6 +41,7 @@ export const Welcome = () => {
   return (
     <Communication
       {...object("Configuration", welcomeConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -49,6 +54,7 @@ export const Hello = () => {
   return (
     <Communication
       {...object("Configuration", helloConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -61,6 +67,7 @@ export const Empty = () => {
   return (
     <Communication
       {...object("Configuration", emptyConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -73,6 +80,7 @@ export const Error = () => {
   return (
     <Communication
       {...object("Configuration", errorConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -85,6 +93,7 @@ export const Thanks = () => {
   return (
     <Communication
       {...object("Configuration", thanksConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -106,11 +115,11 @@ const customConfig = {
     actions: {
       primary: {
         label: "Documentation",
-        action: () => alert("Documentation button clicked"),
+        target: "documentation",
       },
       secondary: {
         label: "Samples",
-        action: () => alert("Samples button clicked"),
+        target: "samples",
       },
     },
   },
@@ -119,6 +128,7 @@ export const Custom = () => {
   return (
     <Communication
       {...object("Configuration", customConfig, communicationKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };
@@ -143,11 +153,11 @@ const customThemedImageConfig = {
     actions: {
       primary: {
         label: "Documentation",
-        action: () => alert("Documentation button clicked"),
+        target: "documentation",
       },
       secondary: {
         label: "Samples",
-        action: () => alert("Samples button clicked"),
+        target: "samples",
       },
     },
   },
@@ -160,6 +170,7 @@ export const CustomImageThemeSupport = () => {
         customThemedImageConfig,
         communicationKnobGroupID
       )}
+      {...eventsFromNames}
     />
   );
 };

--- a/src/stories/Form.stories.tsx
+++ b/src/stories/Form.stories.tsx
@@ -8,6 +8,7 @@ const fake = (template: string) => {
   return { "en-US": fakerEN.fake(template), fa: fakerFA.fake(template) };
 };
 
+import { actions } from "@storybook/addon-actions";
 import { object } from "@storybook/addon-knobs";
 
 import { Form, TInputWidth, TFormErrors } from "../components/Form/Form";
@@ -16,6 +17,8 @@ export default {
   title: "UI Templates/Form",
   component: Form,
 };
+
+const eventsFromNames = actions("onInteraction");
 
 const formKnobGroupID = "Form";
 
@@ -128,7 +131,10 @@ const kitchenSinkConfig = {
 
 export const KitchenSink = () => {
   return (
-    <Form {...object("Configuration", kitchenSinkConfig, formKnobGroupID)} />
+    <Form
+      {...object("Configuration", kitchenSinkConfig, formKnobGroupID)}
+      {...eventsFromNames}
+    />
   );
 };
 7;
@@ -147,6 +153,7 @@ export const KitchenSinkWithErrors = () => {
   return (
     <Form
       {...object("Configuration", kitchenSinkWithErrorsConfig, formKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };

--- a/src/stories/List.stories.tsx
+++ b/src/stories/List.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { object, boolean } from "@storybook/addon-knobs";
+import { actions } from "@storybook/addon-actions";
 
 import { List, TSortable } from "..";
 
@@ -7,6 +8,8 @@ export default {
   title: "UI Templates/List",
   component: List,
 };
+
+const eventsFromNames = actions("onInteraction");
 
 const listKnobGroupID = "List";
 
@@ -16,7 +19,7 @@ export const KitchenSink = () => {
     filters: ["c2", "c3"],
     emptySelectionActionGroups: {
       g1: {
-        a1: { title: "Add", icon: "Add" },
+        a1: { title: "Add", icon: "Add", subject: ["list", "add"] },
       },
     },
     columns: {
@@ -88,6 +91,7 @@ export const KitchenSink = () => {
       truncate={boolean("Truncate", false, listKnobGroupID)}
       selectable={boolean("Selectable", true, listKnobGroupID)}
       {...object("Configuration", listConfig, listKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { object, boolean } from "@storybook/addon-knobs";
+import { actions } from "@storybook/addon-actions";
 
 import { Table, TSortable } from "..";
 
@@ -7,6 +8,8 @@ export default {
   title: "Components/Table",
   component: Table,
 };
+
+const eventsFromNames = actions("onInteraction");
 
 const tableKnobGroupID = "Table";
 
@@ -81,6 +84,7 @@ export const KitchenSink = () => {
       truncate={boolean("Truncate", false, tableKnobGroupID)}
       selectable={boolean("Selectable", true, tableKnobGroupID)}
       {...object("Configuration", tableConfig, tableKnobGroupID)}
+      {...eventsFromNames}
     />
   );
 };

--- a/src/stories/Toolbar.stories.tsx
+++ b/src/stories/Toolbar.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { object } from "@storybook/addon-knobs";
+import { actions } from "@storybook/addon-actions";
 import { Toolbar } from "..";
 
 export default {
@@ -7,26 +8,32 @@ export default {
   component: Toolbar,
 };
 
+const eventsFromNames = actions("onInteraction");
+
 const toolbarKnobGroupID = "Toolbar";
 
 export const KitchenSink = () => {
   const toolbarConfig = {
     actionGroups: {
       g1: {
-        a1: { title: "Ginger", icon: "GalleryNew" },
-        a2: { title: "Carrot", icon: "GalleryNewLarge" },
-        a3: { title: "Parsnip", icon: "GalleryNew" },
-        a4: { title: "Potato", icon: "GalleryNewLarge" },
-        a5: { title: "Radish", icon: "GalleryNew" },
-        a6: { title: "Yam", icon: "GalleryNewLarge" },
+        a1: { title: "Ginger", icon: "GalleryNew", subject: "ginger" },
+        a2: { title: "Carrot", icon: "GalleryNewLarge", subject: "carrot" },
+        a3: { title: "Parsnip", icon: "GalleryNew", subject: "parsnip" },
+        a4: { title: "Potato", icon: "GalleryNewLarge", subject: "potato" },
+        a5: { title: "Radish", icon: "GalleryNew", subject: "radish" },
+        a6: { title: "Yam", icon: "GalleryNewLarge", subject: "yam" },
       },
       g2: {
-        a1: { title: "Cucumber", icon: "GalleryNew" },
-        a2: { title: "Avocado", icon: "GalleryNewLarge" },
-        a3: { title: "Pumpkin", icon: "GalleryNew" },
-        a4: { title: "Squash", icon: "GalleryNewLarge" },
-        a5: { title: "Tomato", icon: "GalleryNew" },
-        a6: { title: "Watermelon", icon: "GalleryNewLarge" },
+        a1: { title: "Cucumber", icon: "GalleryNew", subject: "cucumber" },
+        a2: { title: "Avocado", icon: "GalleryNewLarge", subject: "avocado" },
+        a3: { title: "Pumpkin", icon: "GalleryNew", subject: "pumpkin" },
+        a4: { title: "Squash", icon: "GalleryNewLarge", subject: "squash" },
+        a5: { title: "Tomato", icon: "GalleryNew", subject: "tomato" },
+        a6: {
+          title: "Watermelon",
+          icon: "GalleryNewLarge",
+          subject: "watermelon",
+        },
       },
     },
     filters: [
@@ -66,7 +73,10 @@ export const KitchenSink = () => {
     find: true,
   };
   return (
-    <Toolbar {...object("Configuration", toolbarConfig, toolbarKnobGroupID)} />
+    <Toolbar
+      {...object("Configuration", toolbarConfig, toolbarKnobGroupID)}
+      {...eventsFromNames}
+    />
   );
 };
 
@@ -74,15 +84,18 @@ export const OnlyAFewActions = () => {
   const toolbarConfig = {
     actionGroups: {
       h1: {
-        b1: { title: "Arugula", icon: "GalleryNewLarge" },
-        b2: { title: "Cabbage", icon: "GalleryNew" },
+        b1: { title: "Arugula", icon: "GalleryNewLarge", subject: "arugula" },
+        b2: { title: "Cabbage", icon: "GalleryNew", subject: "cabbage" },
       },
     },
     filters: [],
     find: false,
   };
   return (
-    <Toolbar {...object("Configuration", toolbarConfig, toolbarKnobGroupID)} />
+    <Toolbar
+      {...object("Configuration", toolbarConfig, toolbarKnobGroupID)}
+      {...eventsFromNames}
+    />
   );
 };
 
@@ -105,6 +118,9 @@ export const SingleSelectFilterAndFind = () => {
     find: true,
   };
   return (
-    <Toolbar {...object("Configuration", toolbarConfig, toolbarKnobGroupID)} />
+    <Toolbar
+      {...object("Configuration", toolbarConfig, toolbarKnobGroupID)}
+      {...eventsFromNames}
+    />
   );
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -3,7 +3,7 @@ import { TTextObject } from "../translations";
 
 export type TAction = {
   title: string;
-  subject: string[] | string;
+  subject?: string[] | string;
   icon?: string;
   multi?: boolean;
 };
@@ -12,10 +12,6 @@ export type actionKey = string;
 
 export type TActions = {
   [actionKey: string]: TAction;
-};
-
-export type TActionsWithoutSubjects = {
-  [actionKey: string]: Omit<TAction, "subject">;
 };
 
 export type TUser = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -3,13 +3,19 @@ import { TTextObject } from "../translations";
 
 export type TAction = {
   title: string;
+  subject: string[] | string;
   icon?: string;
   multi?: boolean;
-  __internal_callback__?: string;
 };
+
+export type actionKey = string;
 
 export type TActions = {
   [actionKey: string]: TAction;
+};
+
+export type TActionsWithoutSubjects = {
+  [actionKey: string]: Omit<TAction, "subject">;
 };
 
 export type TUser = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,13 +1261,6 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/example-data@^8.0.0-beta.0":
-  version "8.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/example-data/-/example-data-8.0.0-beta.0.tgz#b5856403dee8b368e8c72efa97889a9a23e77e40"
-  integrity sha512-i69f/AqgntlybNCIxjzvmoN3D5eEm3t4g3K3+DTC3gP/cX90b40JNINfqIJEn/5B8Zilgb+p236b73sGsXlEyg==
-  dependencies:
-    tslib "^1.10.0"
-
 "@fluentui/keyboard-key@^0.2.7":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@fluentui/keyboard-key/-/keyboard-key-0.2.12.tgz#74eddf4657c164193b6c8855746e691af466441a"
@@ -7462,9 +7455,9 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@Marak/faker.js:
-  version "5.1.0"
-  resolved "https://codeload.github.com/Marak/faker.js/tar.gz/91dc8a3372426bc691be56153b33e81a16459f49"
+faker@thure/faker.js#v5.1.1:
+  version "5.1.1"
+  resolved "https://codeload.github.com/thure/faker.js/tar.gz/3e9db39ce9d63f1d8729b8506969644e413e1304"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7455,9 +7455,9 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@thure/faker.js#v5.1.1:
-  version "5.1.1"
-  resolved "https://codeload.github.com/thure/faker.js/tar.gz/3e9db39ce9d63f1d8729b8506969644e413e1304"
+faker@thure/faker.js#v5.1.2:
+  version "5.1.2"
+  resolved "https://codeload.github.com/thure/faker.js/tar.gz/d17c2e5255e27ed7da9bd65facb4e6981cdf1465"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,6 +1261,13 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
+"@fluentui/example-data@^8.0.0-beta.0":
+  version "8.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/example-data/-/example-data-8.0.0-beta.0.tgz#b5856403dee8b368e8c72efa97889a9a23e77e40"
+  integrity sha512-i69f/AqgntlybNCIxjzvmoN3D5eEm3t4g3K3+DTC3gP/cX90b40JNINfqIJEn/5B8Zilgb+p236b73sGsXlEyg==
+  dependencies:
+    tslib "^1.10.0"
+
 "@fluentui/keyboard-key@^0.2.7":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@fluentui/keyboard-key/-/keyboard-key-0.2.12.tgz#74eddf4657c164193b6c8855746e691af466441a"


### PR DESCRIPTION
## [Open in Storybook ↗️](https://dev-int.teams.microsoft.com/storybook/on-update/index.html)

This PR adds the `onInteraction` optional handler to interactive HVCs, which allows developers to handle user interactions in the HVCs in a way that is forward-compatible with a JSON API. This replaces the earlier `__internal_callbacks__` handler from before which was not exposed to developers.

All HVCs will call `onInteraction` for interactions designed for developer response with a monolithic object payload like `{ event, target, subject, action }` for Toolbar and List, `{ event, target, formState }` for Forms, and `{ event, target, items }` or `{ event, target, lanes }` for Boards.

We may like to iterate on this schema.

Please note that `lanes` updates from Board are misrepresented in Storybook; object key order is guaranteed in this library's target dialects, but Storybook sorts object keys alphabetically when displaying them.

<img width="834" alt="Screen Shot 2021-01-13 at 14 09 08" src="https://user-images.githubusercontent.com/855039/104516459-33b0f080-55a9-11eb-9d85-1116b7f90441.png">
<img width="835" alt="Screen Shot 2021-01-13 at 14 08 10" src="https://user-images.githubusercontent.com/855039/104516463-34e21d80-55a9-11eb-9da6-7684b38422a8.png">