### PR TITLE
Ship CommonJS modules as well

### DIFF
--- a/change/@fluentui-react-teams-1dc77e82-692d-49f7-9b89-3863d5535c8f.json
+++ b/change/@fluentui-react-teams-1dc77e82-692d-49f7-9b89-3863d5535c8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add CommonJS output for NodeJS compat",
+  "packageName": "@fluentui/react-teams",
+  "email": "david@zuko.me",
+  "dependentChangeType": "patch"
+}

--- a/just.config.ts
+++ b/just.config.ts
@@ -1,6 +1,13 @@
 import * as util from "util";
 import _rimraf from "rimraf";
-import { task, series, jestTask, tscTask, eslintTask } from "just-scripts";
+import {
+  task,
+  parallel,
+  series,
+  jestTask,
+  tscTask,
+  eslintTask,
+} from "just-scripts";
 import {
   startStorybookTask,
   buildStorybookTask,
@@ -9,7 +16,19 @@ import {
 const rimraf = util.promisify(_rimraf as any);
 
 task("clean", () => rimraf("lib"));
-task("build:tsc", tscTask());
+task(
+  "build:tsc",
+  parallel(
+    tscTask({
+      module: "CommonJS",
+      outDir: "lib/cjs",
+    }),
+    tscTask({
+      module: "ES2020",
+      outDir: "lib/esm",
+    })
+  )
+);
 task("build", series("clean", "build:tsc"));
 
 task("test", jestTask());

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Teams components in the Fluent UI design language written in React",
   "repository": "https://github.com/OfficeDev/microsoft-teams-ui-component-library.git",
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
   "scripts": {
     "build": "just-scripts build",
     "build:storybook": "just-scripts build:storybook",


### PR DESCRIPTION
Changes our dist output from: `/lib/index.js` to `/lib/{cjs,esm}/index.js`. _Technically_ a breaking change if any consumer is importing from a specific path from the package, but that's debatable since reaching into a package's internal folder structure isn't documented to be consistent.

Fixes https://github.com/OfficeDev/microsoft-teams-ui-component-library/issues/56