### PR TITLE
Disable Storybook docs tab

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,10 @@ module.exports = {
   addons: [
     "@storybook/addon-actions",
     "@storybook/addon-links",
-    "@storybook/addon-docs",
+    // Disabled because we don't have any documentation in Storybook yet,
+    // so the Docs tab is just a blank page.
+    // Keeping the plugin here because we probably should have docs...
+    // "@storybook/addon-docs",
     "@storybook/addon-viewport/register",
     "@storybook/addon-a11y/register",
     "@storybook/addon-knobs/register",

--- a/change/@fluentui-react-teams-f0bd198e-f770-4f9f-b6fc-c6d410467b6f.json
+++ b/change/@fluentui-react-teams-f0bd198e-f770-4f9f-b6fc-c6d410467b6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable Storybook docs tab",
+  "packageName": "@fluentui/react-teams",
+  "email": "david@zuko.me",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
I left the addon in the storybook configuration since we probably(?) want to have documentation, and this way we just have to remove a comment once the documentation is properly setup. If we don't intend to have docs, I can go ahead and remove the addon altogether.