### PR TITLE
Allow ReactElements to be used as icons

### DIFF
--- a/change/@fluentui-react-teams-3b090b6d-c91a-49c7-9bdf-bca9b80fa0ed.json
+++ b/change/@fluentui-react-teams-3b090b6d-c91a-49c7-9bdf-bca9b80fa0ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow a React element to be used as an icon",
+  "packageName": "@fluentui/react-teams",
+  "email": "david@zuko.me",
+  "dependentChangeType": "patch"
+}

--- a/src/lib/Icon.tsx
+++ b/src/lib/Icon.tsx
@@ -10,30 +10,27 @@ import {
 } from "@fluentui/react-icons-northstar";
 
 export interface IIconProps {
-  icon?: string;
+  icon?: string | React.ReactElement;
 }
 
 export default ({ icon }: IIconProps) => {
-  let iconElement = null;
+  if (React.isValidElement(icon)) {
+    return icon;
+  }
   switch (icon) {
     case "Add":
-      iconElement = <AddIcon outline />;
-      break;
+      return <AddIcon outline />;
     case "Edit":
-      iconElement = <EditIcon outline />;
-      break;
+      return <EditIcon outline />;
     case "GalleryNew":
-      iconElement = <GalleryNewIcon outline />;
-      break;
+      return <GalleryNewIcon outline />;
     case "GalleryNewLarge":
-      iconElement = <GalleryNewLargeIcon outline />;
-      break;
+      return <GalleryNewLargeIcon outline />;
     case "ShareGeneric":
-      iconElement = <ShareGenericIcon outline />;
-      break;
+      return <ShareGenericIcon outline />;
     case "TrashCan":
-      iconElement = <TrashCanIcon outline />;
-      break;
+      return <TrashCanIcon outline />;
+    default:
+      return null;
   }
-  return iconElement;
 };


### PR DESCRIPTION
Currently we have a limited, hardcoded list of icons. As seen in https://github.com/OfficeDev/microsoft-teams-ui-component-library/issues/62, it is extremely likely that a user will want to use an icon that isn't in this list. The most straightforward solution is to allow a React element to be passed in place of a string value, which allows users to provide any icon they choose (ideally one from @fluentui/react-icons-northstar).

One drawback of allowing icons to be React elements is that the JSON configuration is no longer serializable. Honestly, I think that's reasonable since on top of being idiomatic React, it's a userland decision and if we needed to serialize it back we could (read: should) sanitize it anyways. Still, worth calling out. The _other_ drawback is that it allows _any_ component to be used as an icon. If we're hoping to inspire consistency across the Teams platform then this works against that. It might be wise for this to be documented primarily as an escape hatch and that developers should stick to Teams icons wherever possible.

A different solution would be to offer an API such as:

```tsx
const registry = new Map()
export const registerIcon = (name: string, component: React.ComponentType) => {
  registry.set(name, component)
}
const Icon = ({ icon }: IIconProps) => {
  const Icon = registry.get(icon)
  return Icon ? <Icon /> : null
}
registerIcon("MyCustomIcon", MyCustomIcon)
```

I'm personally not a fan of this as the primary API because it means all used icons must be registered before they can be used, which would increase bundle size if done upfront or possibly buggy behavior if done as-needed. Users would be able to lazy-load the icon to circumvent the bundle size issue, but at that point the API simply becomes unergonomic.

That said, it may offer a reasonable addition to this change if we're keen on representing component API's strictly as serializable JSON.

Lastly, a third solution would be to enumerate all "approved" icons ahead of time and manage the lazy-loading ourselves. I definitely do not think this is a worthwhile pursuit, but wanted to mention it for completeness and to highlight the drawbacks of supporting, and restricting users to, a large catalog of icons. This would become even more tricky since we treat the Fluent icons package as a peer dependency. In short: there be dragons.