### PR TITLE
Updating lodash version due to security flaws in older version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fluentui/react-icons-northstar": "^0.54.0",
     "chart.js": "^2.9.4",
     "classnames": "2.x",
-    "lodash": "4.x",
+    "lodash": "4.17.21",
     "immer": "^9.0.1",
     "react-beautiful-dnd": "^13.0.0",
     "react-perfect-scrollbar": "^1.5.8"
@@ -53,7 +53,7 @@
     "@types/classnames": "^2.2.10",
     "@types/faker": "^5.1.2",
     "@types/jest": "^26.0.4",
-    "@types/lodash": "^4.14.158",
+    "@types/lodash": "^4.14.176",
     "@types/react": "^16.8.25",
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^16.8.4",
@@ -87,6 +87,9 @@
     "tslib": "^2.0.0",
     "typescript": "^3.9.7",
     "webpack": "~4.43.0"
+  },
+  "resolutions": {
+    "lodash": "4.17.21"
   },
   "files": [
     "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,10 +3105,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.158":
-  version "4.14.161"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
-  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+"@types/lodash@^4.14.176":
+  version "4.14.176"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
+  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
 
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.2"
@@ -10689,15 +10689,10 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@~4.17.15:
+lodash@4.17.21, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@~4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
Upgrading lodash to the latest version due to 
CVE-2021-23337 in lodash 4.17.20
https://nvd.nist.gov/vuln/detail/CVE-2021-23337