### PR TITLE
Keyboard access fixes for charts

### DIFF
--- a/change/@fluentui-react-teams-a3bef34c-4317-45c2-834b-bef528f424e7.json
+++ b/change/@fluentui-react-teams-a3bef34c-4317-45c2-834b-bef528f424e7.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Implement widget body filtering.",
-  "packageName": "@fluentui/react-teams",
-  "email": "willshown@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-teams-e5e748e5-47a6-460f-938f-beb129644da4.json
+++ b/change/@fluentui-react-teams-e5e748e5-47a6-460f-938f-beb129644da4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check against falsiness of data point before setting styles.",
+  "packageName": "@fluentui/react-teams",
+  "email": "willshown@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-teams",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "Teams components in the Fluent UI design language written in React",
   "repository": "https://github.com/OfficeDev/microsoft-teams-ui-component-library.git",
   "license": "MIT",

--- a/src/components/Chart/Charts/Bar.tsx
+++ b/src/components/Chart/Charts/Bar.tsx
@@ -159,9 +159,10 @@ export const BarChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -169,11 +170,13 @@ export const BarChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -195,9 +198,8 @@ export const BarChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -232,14 +234,15 @@ export const BarChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowRight":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowLeft":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
         case "ArrowUp":
           e.preventDefault();
@@ -303,8 +306,8 @@ export const BarChart = ({
 
   function onLegendClick(datasetIndex: number) {
     if (!chartRef.current) return;
-    chartRef.current.data.datasets![datasetIndex].hidden = !chartRef.current
-      .data.datasets![datasetIndex].hidden;
+    chartRef.current.data.datasets![datasetIndex].hidden =
+      !chartRef.current.data.datasets![datasetIndex].hidden;
     chartRef.current.update();
   }
 

--- a/src/components/Chart/Charts/BarHorizontal.tsx
+++ b/src/components/Chart/Charts/BarHorizontal.tsx
@@ -178,9 +178,10 @@ export const BarHorizontalChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -188,11 +189,13 @@ export const BarHorizontalChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -214,9 +217,8 @@ export const BarHorizontalChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -251,14 +253,15 @@ export const BarHorizontalChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowUp":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
       }
 
@@ -304,8 +307,8 @@ export const BarHorizontalChart = ({
 
   function onLegendClick(datasetIndex: number) {
     if (!chartRef.current) return;
-    chartRef.current.data.datasets![datasetIndex].hidden = !chartRef.current
-      .data.datasets![datasetIndex].hidden;
+    chartRef.current.data.datasets![datasetIndex].hidden =
+      !chartRef.current.data.datasets![datasetIndex].hidden;
     chartRef.current.update();
   }
 

--- a/src/components/Chart/Charts/Bubble.tsx
+++ b/src/components/Chart/Charts/Bubble.tsx
@@ -130,9 +130,10 @@ export const BubbleChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -140,11 +141,13 @@ export const BubbleChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -166,9 +169,8 @@ export const BubbleChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -203,14 +205,15 @@ export const BubbleChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowRight":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowLeft":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
         case "ArrowUp":
         case "ArrowDown":
@@ -221,11 +224,9 @@ export const BubbleChart = ({
               (dataset) => dataset.data[selectedIndex]
             );
             // Sort an array to define next available number
-            const sorted = ([
-              ...Array.from(new Set(values)),
-            ] as IBubbleChartData[]).sort(
-              (a: IBubbleChartData, b: IBubbleChartData) => a.y - b.y
-            );
+            const sorted = (
+              [...Array.from(new Set(values))] as IBubbleChartData[]
+            ).sort((a: IBubbleChartData, b: IBubbleChartData) => a.y - b.y);
             let nextValue =
               sorted[
                 sorted.findIndex((v) => v === values[selectedDataSet]) +
@@ -244,7 +245,7 @@ export const BubbleChart = ({
               );
             }
             selectedDataSet = nextDataSet;
-            selectedIndex = selectedIndex % meta().data.length;
+            selectedIndex = selectedIndex % datasetMeta.data.length;
           }
           break;
       }
@@ -291,8 +292,8 @@ export const BubbleChart = ({
 
   function onLegendClick(datasetIndex: number) {
     if (!chartRef.current) return;
-    chartRef.current.data.datasets![datasetIndex].hidden = !chartRef.current
-      .data.datasets![datasetIndex].hidden;
+    chartRef.current.data.datasets![datasetIndex].hidden =
+      !chartRef.current.data.datasets![datasetIndex].hidden;
     chartRef.current.update();
   }
 

--- a/src/components/Chart/Charts/Line.tsx
+++ b/src/components/Chart/Charts/Line.tsx
@@ -205,9 +205,10 @@ export const LineChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -215,11 +216,13 @@ export const LineChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -241,9 +244,8 @@ export const LineChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -271,14 +273,15 @@ export const LineChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowRight":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowLeft":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
         case "ArrowUp":
         case "ArrowDown":
@@ -310,7 +313,7 @@ export const LineChart = ({
               );
             }
             selectedDataSet = nextDataSet;
-            selectedIndex = selectedIndex % meta().data.length;
+            selectedIndex = selectedIndex % datasetMeta.data.length;
           }
           break;
       }
@@ -358,8 +361,8 @@ export const LineChart = ({
 
   function onLegendClick(datasetIndex: number) {
     if (!chartRef.current) return;
-    chartRef.current.data.datasets![datasetIndex].hidden = !chartRef.current
-      .data.datasets![datasetIndex].hidden;
+    chartRef.current.data.datasets![datasetIndex].hidden =
+      !chartRef.current.data.datasets![datasetIndex].hidden;
     chartRef.current.update();
   }
 

--- a/src/components/Chart/Charts/LineStacked.tsx
+++ b/src/components/Chart/Charts/LineStacked.tsx
@@ -158,9 +158,10 @@ export const LineStackedChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -168,11 +169,13 @@ export const LineStackedChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -194,9 +197,8 @@ export const LineStackedChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -231,14 +233,15 @@ export const LineStackedChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowRight":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowLeft":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
         case "ArrowUp":
           e.preventDefault();
@@ -302,8 +305,8 @@ export const LineStackedChart = ({
 
   function onLegendClick(datasetIndex: number) {
     if (!chartRef.current) return;
-    chartRef.current.data.datasets![datasetIndex].hidden = !chartRef.current
-      .data.datasets![datasetIndex].hidden;
+    chartRef.current.data.datasets![datasetIndex].hidden =
+      !chartRef.current.data.datasets![datasetIndex].hidden;
     chartRef.current.update();
   }
 

--- a/src/components/Chart/Charts/Pie.tsx
+++ b/src/components/Chart/Charts/Pie.tsx
@@ -156,9 +156,10 @@ export const PieChart = ({
     }
 
     function removeDataPointsHoverStates() {
-      if (selectedIndex > -1) {
-        meta().controller.removeHoverStyle(
-          meta().data[selectedIndex],
+      const datasetMeta = meta();
+      if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        datasetMeta.controller.removeHoverStyle(
+          datasetMeta.data[selectedIndex],
           0,
           selectedIndex
         );
@@ -166,11 +167,13 @@ export const PieChart = ({
     }
 
     function hoverDataPoint(pointID: number) {
-      meta().controller.setHoverStyle(
-        meta().data[pointID],
-        selectedDataSet,
-        pointID
-      );
+      const datasetMeta = meta();
+      if (datasetMeta.data[pointID])
+        datasetMeta.controller.setHoverStyle(
+          datasetMeta.data[pointID],
+          selectedDataSet,
+          pointID
+        );
     }
 
     function showFocusedDataPoint() {
@@ -192,9 +195,8 @@ export const PieChart = ({
     function resetChartStates() {
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
-      const requestedElem = chart.getDatasetMeta(selectedDataSet).data[
-        selectedIndex
-      ];
+      const requestedElem =
+        chart.getDatasetMeta(selectedDataSet).data[selectedIndex];
       activeElements.find((v: any, i: number) => {
         if (requestedElem._index === v._index) {
           activeElements.splice(i, 1);
@@ -229,16 +231,17 @@ export const PieChart = ({
 
     function changeFocus(e: KeyboardEvent) {
       removeDataPointsHoverStates();
+      const datasetMeta = meta();
       switch (e.key) {
         case "ArrowRight":
         case "ArrowUp":
           e.preventDefault();
-          selectedIndex = (selectedIndex + 1) % meta().data.length;
+          selectedIndex = (selectedIndex + 1) % datasetMeta.data.length;
           break;
         case "ArrowLeft":
         case "ArrowDown":
           e.preventDefault();
-          selectedIndex = (selectedIndex || meta().data.length) - 1;
+          selectedIndex = (selectedIndex || datasetMeta.data.length) - 1;
           break;
       }
 

--- a/src/components/Dashboard/DashboardWidget.tsx
+++ b/src/components/Dashboard/DashboardWidget.tsx
@@ -221,8 +221,6 @@ export const Widget = ({
   const activeBody =
     (activeFilter && bodyByFilter && bodyByFilter[activeFilter]) || body;
 
-  debugger;
-
   return (
     <Card styles={cardStyle} fluid>
       <FluentUIThemeConsumer


### PR DESCRIPTION
In some situations beyond Storybook, charts occasionally have falsy data point values. This PR avoids passing falsy values to ChartJS functions that crash on such values.