### PR TITLE
Announce tooltips in charts

### DIFF
--- a/change/@fluentui-react-teams-2ce35e9e-fc11-41ec-915e-270dc662c118.json
+++ b/change/@fluentui-react-teams-2ce35e9e-fc11-41ec-915e-270dc662c118.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add descriptive label option to widget links.",
+  "comment": "Cause screen readers to announce tooltip content as the tooltip changes in chart canvases.",
   "packageName": "@fluentui/react-teams",
   "email": "willshown@microsoft.com",
   "dependentChangeType": "patch"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-teams",
-  "version": "6.2.0-next.4",
+  "version": "6.2.0-next.5",
   "description": "Teams components in the Fluent UI design language written in React",
   "repository": "https://github.com/OfficeDev/microsoft-teams-ui-component-library.git",
   "license": "MIT",

--- a/src/components/Chart/Charts/Bar.tsx
+++ b/src/components/Chart/Charts/Bar.tsx
@@ -335,16 +335,18 @@ export const BarChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
+              role="none"
               data-tooltip={true}
               tabIndex={-1}
               styles={visuallyHidden}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >
-              <p>{item}</p>
-              <span>
-                {getText(t.locale, set.label)}: {set.data[itemKey]}
-              </span>
+              {`${getText(t.locale, set.label)} ${
+                data.labels && Array.isArray(data.labels)
+                  ? getText(t.locale, data.labels[itemKey])
+                  : getText(t.locale, data.labels)
+              }: ${set.data[itemKey]}`}
             </Box>
           ))
         )

--- a/src/components/Chart/Charts/Bar.tsx
+++ b/src/components/Chart/Charts/Bar.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import Chart from "chart.js";
-import { SiteVariablesPrepared } from "@fluentui/react-northstar";
+import { Box, SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { TeamsTheme } from "../../../themes";
 import { IChartData } from "../ChartTypes";
 import {
@@ -14,6 +14,9 @@ import {
 import { ChartContainer } from "./ChartContainer";
 import { buildPattern, chartBarDataPointPatterns } from "../ChartPatterns";
 import { getText } from "../../../translations";
+import { visuallyHidden } from "../../../lib/visuallyHidden";
+import flatten from "lodash/flatten";
+import get from "lodash/get";
 
 export const BarChart = ({
   title,
@@ -27,13 +30,11 @@ export const BarChart = ({
   stacked?: boolean;
 }) => {
   const { colorScheme, theme, colors, t } = siteVariables;
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
-  const chartRef = React.useRef<Chart | undefined>();
-  const chartId = React.useMemo(
-    () => Math.random().toString(36).substr(2, 9),
-    []
-  );
-  const chartDataPointColors = React.useMemo(
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<Chart | undefined>();
+  const chartId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+  const chartDataPointColors = useMemo(
     () => [
       colors.brand["600"],
       colors.brand["200"],
@@ -97,7 +98,7 @@ export const BarChart = ({
     let selectedIndex = -1;
     let selectedDataSet = 0;
 
-    if (!canvasRef.current) return;
+    if (!(canvasRef.current && containerRef.current)) return;
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
     const config: any = chartConfig({ type: "bar" });
@@ -188,14 +189,18 @@ export const BarChart = ({
         index: selectedIndex,
         siteVariables,
       });
-      document
-        .getElementById(
-          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
-        )
-        ?.focus();
+      const tooltipAnnoucement = document.getElementById(
+        `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+      );
+      if (tooltipAnnoucement) {
+        tooltipAnnoucement.focus();
+      }
     }
 
-    function resetChartStates() {
+    function resetChartStates(e: FocusEvent) {
+      if (get(e, ["relatedTarget", "dataset", "tooltip"], false)) {
+        return;
+      }
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
       const requestedElem =
@@ -267,15 +272,18 @@ export const BarChart = ({
       showFocusedDataPoint();
     }
 
-    canvasRef.current.addEventListener("click", removeFocusStyleOnClick);
-    canvasRef.current.addEventListener("keydown", changeFocus);
-    canvasRef.current.addEventListener("focusout", resetChartStates);
+    containerRef.current.addEventListener("click", removeFocusStyleOnClick);
+    containerRef.current.addEventListener("keyup", changeFocus);
+    containerRef.current.addEventListener("focusout", resetChartStates);
     return () => {
       if (!chartRef.current) return;
-      if (canvasRef.current) {
-        canvasRef.current.removeEventListener("click", removeFocusStyleOnClick);
-        canvasRef.current.removeEventListener("keydown", changeFocus);
-        canvasRef.current.removeEventListener("focusout", resetChartStates);
+      if (containerRef.current) {
+        containerRef.current.removeEventListener(
+          "click",
+          removeFocusStyleOnClick
+        );
+        containerRef.current.removeEventListener("keyup", changeFocus);
+        containerRef.current.removeEventListener("focusout", resetChartStates);
       }
       chartRef.current.destroy();
     };
@@ -315,31 +323,32 @@ export const BarChart = ({
     <ChartContainer
       siteVariables={siteVariables}
       data={data}
+      chartId={chartId}
+      chartLabel={title}
+      canvasRef={canvasRef}
+      containerRef={containerRef}
       chartDataPointColors={chartDataPointColors}
       patterns={chartBarDataPointPatterns}
       onLegendClick={onLegendClick}
-    >
-      <canvas
-        id={chartId}
-        ref={canvasRef}
-        tabIndex={0}
-        style={{
-          userSelect: "none",
-        }}
-        aria-label={title}
-      >
-        {data.datasets.map((set, setKey) =>
-          (set.data as number[]).forEach((item: number, itemKey: number) => (
+      tooltipAnnouncements={flatten(
+        data.datasets.map((set, setKey) =>
+          (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
-            <div key={itemKey} id={`${chartId}-tooltip-${setKey}-${itemKey}`}>
+            <Box
+              data-tooltip={true}
+              tabIndex={-1}
+              styles={visuallyHidden}
+              key={itemKey}
+              id={`${chartId}-tooltip-${setKey}-${itemKey}`}
+            >
               <p>{item}</p>
               <span>
                 {getText(t.locale, set.label)}: {set.data[itemKey]}
               </span>
-            </div>
+            </Box>
           ))
-        )}
-      </canvas>
-    </ChartContainer>
+        )
+      )}
+    />
   );
 };

--- a/src/components/Chart/Charts/Bar.tsx
+++ b/src/components/Chart/Charts/Bar.tsx
@@ -162,6 +162,12 @@ export const BarChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -193,6 +199,7 @@ export const BarChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -335,10 +342,9 @@ export const BarChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
-              role="none"
               data-tooltip={true}
               tabIndex={-1}
-              styles={visuallyHidden}
+              styles={{ ...visuallyHidden, display: "none" }}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >

--- a/src/components/Chart/Charts/BarHorizontal.tsx
+++ b/src/components/Chart/Charts/BarHorizontal.tsx
@@ -181,6 +181,12 @@ export const BarHorizontalChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -212,6 +218,7 @@ export const BarHorizontalChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -336,10 +343,9 @@ export const BarHorizontalChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
-              role="none"
               data-tooltip={true}
               tabIndex={-1}
-              styles={visuallyHidden}
+              styles={{ ...visuallyHidden, display: "none" }}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >

--- a/src/components/Chart/Charts/BarHorizontal.tsx
+++ b/src/components/Chart/Charts/BarHorizontal.tsx
@@ -336,16 +336,18 @@ export const BarHorizontalChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
+              role="none"
               data-tooltip={true}
               tabIndex={-1}
               styles={visuallyHidden}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >
-              <p>{item}</p>
-              <span>
-                {getText(t.locale, set.label)}: {set.data[itemKey]}
-              </span>
+              {`${getText(t.locale, set.label)} ${
+                data.labels && Array.isArray(data.labels)
+                  ? getText(t.locale, data.labels[itemKey])
+                  : getText(t.locale, data.labels)
+              }: ${set.data[itemKey]}`}
             </Box>
           ))
         )

--- a/src/components/Chart/Charts/BarHorizontal.tsx
+++ b/src/components/Chart/Charts/BarHorizontal.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import Chart from "chart.js";
-import { SiteVariablesPrepared } from "@fluentui/react-northstar";
+import { Box, SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { TeamsTheme } from "../../../themes";
 import { IChartData } from "../ChartTypes";
 import {
@@ -14,6 +14,9 @@ import {
 import { ChartContainer } from "./ChartContainer";
 import { buildPattern, chartBarDataPointPatterns } from "../ChartPatterns";
 import { getText } from "../../../translations";
+import { visuallyHidden } from "../../../lib/visuallyHidden";
+import flatten from "lodash/flatten";
+import get from "lodash/get";
 
 export const BarHorizontalChart = ({
   title,
@@ -27,13 +30,11 @@ export const BarHorizontalChart = ({
   stacked?: boolean;
 }) => {
   const { colorScheme, theme, colors, t } = siteVariables;
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
-  const chartRef = React.useRef<Chart | undefined>();
-  const chartId = React.useMemo(
-    () => Math.random().toString(36).substr(2, 9),
-    []
-  );
-  const chartDataPointColors = React.useMemo(
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<Chart | undefined>();
+  const chartId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+  const chartDataPointColors = useMemo(
     () => [
       colors.brand["600"],
       colors.brand["200"],
@@ -98,7 +99,7 @@ export const BarHorizontalChart = ({
     let selectedIndex = -1;
     let selectedDataSet = 0;
 
-    if (!canvasRef.current) return;
+    if (!(canvasRef.current && containerRef.current)) return;
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
     const config: any = chartConfig({ type: "horizontalBar" });
@@ -207,14 +208,18 @@ export const BarHorizontalChart = ({
         index: selectedIndex,
         siteVariables,
       });
-      document
-        .getElementById(
-          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
-        )
-        ?.focus();
+      const tooltipAnnoucement = document.getElementById(
+        `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+      );
+      if (tooltipAnnoucement) {
+        tooltipAnnoucement.focus();
+      }
     }
 
-    function resetChartStates() {
+    function resetChartStates(e: FocusEvent) {
+      if (get(e, ["relatedTarget", "dataset", "tooltip"], false)) {
+        return;
+      }
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
       const requestedElem =
@@ -268,15 +273,18 @@ export const BarHorizontalChart = ({
       showFocusedDataPoint();
     }
 
-    canvasRef.current.addEventListener("click", removeFocusStyleOnClick);
-    canvasRef.current.addEventListener("keydown", changeFocus);
-    canvasRef.current.addEventListener("focusout", resetChartStates);
+    containerRef.current.addEventListener("click", removeFocusStyleOnClick);
+    containerRef.current.addEventListener("keyup", changeFocus);
+    containerRef.current.addEventListener("focusout", resetChartStates);
     return () => {
       if (!chartRef.current) return;
-      if (canvasRef.current) {
-        canvasRef.current.removeEventListener("click", removeFocusStyleOnClick);
-        canvasRef.current.removeEventListener("keydown", changeFocus);
-        canvasRef.current.removeEventListener("focusout", resetChartStates);
+      if (containerRef.current) {
+        containerRef.current.removeEventListener(
+          "click",
+          removeFocusStyleOnClick
+        );
+        containerRef.current.removeEventListener("keyup", changeFocus);
+        containerRef.current.removeEventListener("focusout", resetChartStates);
       }
       chartRef.current.destroy();
     };
@@ -316,31 +324,32 @@ export const BarHorizontalChart = ({
     <ChartContainer
       siteVariables={siteVariables}
       data={data}
+      chartId={chartId}
+      chartLabel={title}
+      canvasRef={canvasRef}
+      containerRef={containerRef}
       chartDataPointColors={chartDataPointColors}
       patterns={chartBarDataPointPatterns}
       onLegendClick={onLegendClick}
-    >
-      <canvas
-        id={chartId}
-        ref={canvasRef}
-        tabIndex={0}
-        style={{
-          userSelect: "none",
-        }}
-        aria-label={title}
-      >
-        {data.datasets.map((set, setKey) =>
-          (set.data as number[]).forEach((item: number, itemKey: number) => (
+      tooltipAnnouncements={flatten(
+        data.datasets.map((set, setKey) =>
+          (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
-            <div key={itemKey} id={`${chartId}-tooltip-${setKey}-${itemKey}`}>
+            <Box
+              data-tooltip={true}
+              tabIndex={-1}
+              styles={visuallyHidden}
+              key={itemKey}
+              id={`${chartId}-tooltip-${setKey}-${itemKey}`}
+            >
               <p>{item}</p>
               <span>
                 {getText(t.locale, set.label)}: {set.data[itemKey]}
               </span>
-            </div>
+            </Box>
           ))
-        )}
-      </canvas>
-    </ChartContainer>
+        )
+      )}
+    />
   );
 };

--- a/src/components/Chart/Charts/Bubble.tsx
+++ b/src/components/Chart/Charts/Bubble.tsx
@@ -322,17 +322,16 @@ export const BubbleChart = ({
             (item: IBubbleChartData, itemKey: number) => (
               // Generated tooltips for screen readers
               <Box
+                role="none"
                 data-tooltip={true}
                 tabIndex={-1}
                 styles={visuallyHidden}
                 key={itemKey}
                 id={`${chartId}-tooltip-${setKey}-${itemKey}`}
               >
-                <p>{item.x}</p>
-                <span>
-                  {getText(t.locale, set.label)}:{" "}
-                  {(set.data as IBubbleChartData[])[itemKey].y}
-                </span>
+                {`${getText(t.locale, set.label)}: ${
+                  (set.data as IBubbleChartData[])[itemKey].x
+                }, ${(set.data as IBubbleChartData[])[itemKey].y}`}
               </Box>
             )
           )

--- a/src/components/Chart/Charts/Bubble.tsx
+++ b/src/components/Chart/Charts/Bubble.tsx
@@ -133,6 +133,12 @@ export const BubbleChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -164,6 +170,7 @@ export const BubbleChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -322,10 +329,9 @@ export const BubbleChart = ({
             (item: IBubbleChartData, itemKey: number) => (
               // Generated tooltips for screen readers
               <Box
-                role="none"
                 data-tooltip={true}
                 tabIndex={-1}
-                styles={visuallyHidden}
+                styles={{ ...visuallyHidden, display: "none" }}
                 key={itemKey}
                 id={`${chartId}-tooltip-${setKey}-${itemKey}`}
               >

--- a/src/components/Chart/Charts/Bubble.tsx
+++ b/src/components/Chart/Charts/Bubble.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import Chart from "chart.js";
-import { SiteVariablesPrepared } from "@fluentui/react-northstar";
+import { Box, SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { TeamsTheme } from "../../../themes";
 import { IBubbleChartData, IChartData } from "../ChartTypes";
 import {
@@ -12,6 +12,9 @@ import {
 import { ChartContainer } from "./ChartContainer";
 import { buildPattern, chartBubbleDataPointPatterns } from "../ChartPatterns";
 import { getText } from "../../../translations";
+import { visuallyHidden } from "../../../lib/visuallyHidden";
+import flatten from "lodash/flatten";
+import get from "lodash/get";
 
 export const BubbleChart = ({
   title,
@@ -23,13 +26,11 @@ export const BubbleChart = ({
   siteVariables: SiteVariablesPrepared;
 }) => {
   const { colorScheme, theme, t } = siteVariables;
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
-  const chartRef = React.useRef<Chart | undefined>();
-  const chartId = React.useMemo(
-    () => Math.random().toString(36).substr(2, 9),
-    []
-  );
-  const chartDataPointColors = React.useMemo(
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<Chart | undefined>();
+  const chartId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+  const chartDataPointColors = useMemo(
     () => [
       colorScheme.brand.background,
       colorScheme.default.borderHover,
@@ -98,7 +99,7 @@ export const BubbleChart = ({
     let selectedIndex = -1;
     let selectedDataSet = 0;
 
-    if (!canvasRef.current) return;
+    if (!(canvasRef.current && containerRef.current)) return;
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
     const config: any = chartConfig({ type: "bubble" });
@@ -159,14 +160,18 @@ export const BubbleChart = ({
         index: selectedIndex,
         siteVariables,
       });
-      document
-        .getElementById(
-          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
-        )
-        ?.focus();
+      const tooltipAnnoucement = document.getElementById(
+        `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+      );
+      if (tooltipAnnoucement) {
+        tooltipAnnoucement.focus();
+      }
     }
 
-    function resetChartStates() {
+    function resetChartStates(e: FocusEvent) {
+      if (get(e, ["relatedTarget", "dataset", "tooltip"], false)) {
+        return;
+      }
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
       const requestedElem =
@@ -253,15 +258,18 @@ export const BubbleChart = ({
       showFocusedDataPoint();
     }
 
-    canvasRef.current.addEventListener("click", removeFocusStyleOnClick);
-    canvasRef.current.addEventListener("keydown", changeFocus);
-    canvasRef.current.addEventListener("focusout", resetChartStates);
+    containerRef.current.addEventListener("click", removeFocusStyleOnClick);
+    containerRef.current.addEventListener("keyup", changeFocus);
+    containerRef.current.addEventListener("focusout", resetChartStates);
     return () => {
       if (!chartRef.current) return;
-      if (canvasRef.current) {
-        canvasRef.current.removeEventListener("click", removeFocusStyleOnClick);
-        canvasRef.current.removeEventListener("keydown", changeFocus);
-        canvasRef.current.removeEventListener("focusout", resetChartStates);
+      if (containerRef.current) {
+        containerRef.current.removeEventListener(
+          "click",
+          removeFocusStyleOnClick
+        );
+        containerRef.current.removeEventListener("keyup", changeFocus);
+        containerRef.current.removeEventListener("focusout", resetChartStates);
       }
       chartRef.current.destroy();
     };
@@ -301,34 +309,35 @@ export const BubbleChart = ({
     <ChartContainer
       siteVariables={siteVariables}
       data={data}
+      chartId={chartId}
+      chartLabel={title}
+      canvasRef={canvasRef}
+      containerRef={containerRef}
       chartDataPointColors={chartDataPointColors}
       patterns={chartBubbleDataPointPatterns}
       onLegendClick={onLegendClick}
-    >
-      <canvas
-        id={chartId}
-        ref={canvasRef}
-        tabIndex={0}
-        style={{
-          userSelect: "none",
-        }}
-        aria-label={title}
-      >
-        {data.datasets.map((set, setKey) =>
-          (set.data as IBubbleChartData[]).forEach(
+      tooltipAnnouncements={flatten(
+        data.datasets.map((set, setKey) =>
+          (set.data as IBubbleChartData[]).map(
             (item: IBubbleChartData, itemKey: number) => (
               // Generated tooltips for screen readers
-              <div key={itemKey} id={`${chartId}-tooltip-${setKey}-${itemKey}`}>
+              <Box
+                data-tooltip={true}
+                tabIndex={-1}
+                styles={visuallyHidden}
+                key={itemKey}
+                id={`${chartId}-tooltip-${setKey}-${itemKey}`}
+              >
                 <p>{item.x}</p>
                 <span>
                   {getText(t.locale, set.label)}:{" "}
                   {(set.data as IBubbleChartData[])[itemKey].y}
                 </span>
-              </div>
+              </Box>
             )
           )
-        )}
-      </canvas>
-    </ChartContainer>
+        )
+      )}
+    />
   );
 };

--- a/src/components/Chart/Charts/ChartContainer.tsx
+++ b/src/components/Chart/Charts/ChartContainer.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useMemo, MutableRefObject } from "react";
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  MutableRefObject,
+  ReactElement,
+} from "react";
 import {
   Box,
   SiteVariablesPrepared,
@@ -11,7 +17,6 @@ import { TeamsTheme } from "../../../themes";
 import { IChartData, IChartPatterns, ILegendItem } from "../ChartTypes";
 import { legendLabels } from "../ChartPatterns";
 import { getText } from "../../../translations";
-import { visuallyHidden } from "../../../lib/visuallyHidden";
 
 const LabelColorValue = ({
   index,
@@ -164,6 +169,7 @@ export const ChartContainer = ({
   chartLabel,
   canvasRef,
   containerRef,
+  tooltipAnnouncements,
   siteVariables,
   chartDataPointColors,
   onLegendClick,
@@ -175,6 +181,7 @@ export const ChartContainer = ({
   chartLabel: string;
   canvasRef: MutableRefObject<HTMLCanvasElement | null>;
   containerRef: MutableRefObject<HTMLDivElement | null>;
+  tooltipAnnouncements: ReactElement[];
   siteVariables: SiteVariablesPrepared;
   chartDataPointColors: any;
   onLegendClick: (index: number) => void;
@@ -226,25 +233,7 @@ export const ChartContainer = ({
           }}
           aria-label={chartLabel}
         />
-        {data.datasets.map((set, setKey) =>
-          (set.data as number[]).map((item: number, itemKey: number) => (
-            // Generated tooltips for screen readers
-            <Box
-              data-tooltip={true}
-              tabIndex={-1}
-              as="p"
-              key={itemKey}
-              id={`${chartId}-tooltip-${setKey}-${itemKey}`}
-              styles={visuallyHidden}
-            >
-              {`${getText(t.locale, set.label)} ${
-                data.labels && Array.isArray(data.labels)
-                  ? getText(t.locale, data.labels[itemKey])
-                  : getText(t.locale, data.labels)
-              }: ${set.data[itemKey]}`}
-            </Box>
-          ))
-        )}
+        {tooltipAnnouncements}
       </Box>
       <Box>
         <Legend

--- a/src/components/Chart/Charts/Line.tsx
+++ b/src/components/Chart/Charts/Line.tsx
@@ -208,6 +208,12 @@ export const LineChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -239,6 +245,7 @@ export const LineChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -389,10 +396,9 @@ export const LineChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
-              role="none"
               data-tooltip={true}
               tabIndex={-1}
-              styles={visuallyHidden}
+              styles={{ ...visuallyHidden, display: "none" }}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >

--- a/src/components/Chart/Charts/Line.tsx
+++ b/src/components/Chart/Charts/Line.tsx
@@ -389,16 +389,18 @@ export const LineChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
+              role="none"
               data-tooltip={true}
               tabIndex={-1}
               styles={visuallyHidden}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >
-              <p>{item}</p>
-              <span>
-                {getText(t.locale, set.label)}: {set.data[itemKey]}
-              </span>
+              {`${getText(t.locale, set.label)} ${
+                data.labels && Array.isArray(data.labels)
+                  ? getText(t.locale, data.labels[itemKey])
+                  : getText(t.locale, data.labels)
+              }: ${set.data[itemKey]}`}
             </Box>
           ))
         )

--- a/src/components/Chart/Charts/Line.tsx
+++ b/src/components/Chart/Charts/Line.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import Chart from "chart.js";
-import { SiteVariablesPrepared } from "@fluentui/react-northstar";
+import { Box, SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { IChartData } from "../ChartTypes";
 import {
   tooltipTrigger,
@@ -14,6 +14,9 @@ import { TeamsTheme } from "../../../themes";
 import { ChartContainer } from "./ChartContainer";
 import { lineChartPatterns } from "../ChartPatterns";
 import { getText } from "../../../translations";
+import { visuallyHidden } from "../../../lib/visuallyHidden";
+import flatten from "lodash/flatten";
+import get from "lodash/get";
 
 export const LineChart = ({
   title,
@@ -27,13 +30,11 @@ export const LineChart = ({
   gradients?: boolean;
 }) => {
   const { colorScheme, theme, t } = siteVariables;
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
-  const chartRef = React.useRef<Chart | undefined>();
-  const chartId = React.useMemo(
-    () => Math.random().toString(36).substr(2, 9),
-    []
-  );
-  const chartDataPointColors = React.useMemo(
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<Chart | undefined>();
+  const chartId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+  const chartDataPointColors = useMemo(
     () => [
       colorScheme.brand.background,
       colorScheme.default.borderHover,
@@ -164,7 +165,7 @@ export const LineChart = ({
     let selectedIndex = -1;
     let selectedDataSet = 0;
 
-    if (!canvasRef.current) return;
+    if (!(canvasRef.current && containerRef.current)) return;
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
     chartRef.current = new Chart(ctx, {
@@ -234,14 +235,18 @@ export const LineChart = ({
         index: selectedIndex,
         siteVariables,
       });
-      document
-        .getElementById(
-          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
-        )
-        ?.focus();
+      const tooltipAnnoucement = document.getElementById(
+        `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+      );
+      if (tooltipAnnoucement) {
+        tooltipAnnoucement.focus();
+      }
     }
 
-    function resetChartStates() {
+    function resetChartStates(e: FocusEvent) {
+      if (get(e, ["relatedTarget", "dataset", "tooltip"], false)) {
+        return;
+      }
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
       const requestedElem =
@@ -321,15 +326,18 @@ export const LineChart = ({
       showFocusedDataPoint();
     }
 
-    canvasRef.current.addEventListener("click", removeFocusStyleOnClick);
-    canvasRef.current.addEventListener("keydown", changeFocus);
-    canvasRef.current.addEventListener("focusout", resetChartStates);
+    containerRef.current.addEventListener("click", removeFocusStyleOnClick);
+    containerRef.current.addEventListener("keyup", changeFocus);
+    containerRef.current.addEventListener("focusout", resetChartStates);
     return () => {
       if (!chartRef.current) return;
-      if (canvasRef.current) {
-        canvasRef.current.removeEventListener("click", removeFocusStyleOnClick);
-        canvasRef.current.removeEventListener("keydown", changeFocus);
-        canvasRef.current.removeEventListener("focusout", resetChartStates);
+      if (containerRef.current) {
+        containerRef.current.removeEventListener(
+          "click",
+          removeFocusStyleOnClick
+        );
+        containerRef.current.removeEventListener("keyup", changeFocus);
+        containerRef.current.removeEventListener("focusout", resetChartStates);
       }
       chartRef.current.destroy();
     };
@@ -370,30 +378,31 @@ export const LineChart = ({
     <ChartContainer
       siteVariables={siteVariables}
       data={data}
+      chartId={chartId}
+      chartLabel={title}
+      canvasRef={canvasRef}
+      containerRef={containerRef}
       chartDataPointColors={chartDataPointColors}
       onLegendClick={onLegendClick}
-    >
-      <canvas
-        id={chartId}
-        ref={canvasRef}
-        tabIndex={0}
-        style={{
-          userSelect: "none",
-        }}
-        aria-label={title}
-      >
-        {data.datasets.map((set, setKey) =>
-          (set.data as number[]).forEach((item: number, itemKey: number) => (
+      tooltipAnnouncements={flatten(
+        data.datasets.map((set, setKey) =>
+          (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
-            <div key={itemKey} id={`${chartId}-tooltip-${setKey}-${itemKey}`}>
+            <Box
+              data-tooltip={true}
+              tabIndex={-1}
+              styles={visuallyHidden}
+              key={itemKey}
+              id={`${chartId}-tooltip-${setKey}-${itemKey}`}
+            >
               <p>{item}</p>
               <span>
                 {getText(t.locale, set.label)}: {set.data[itemKey]}
               </span>
-            </div>
+            </Box>
           ))
-        )}
-      </canvas>
-    </ChartContainer>
+        )
+      )}
+    />
   );
 };

--- a/src/components/Chart/Charts/LineStacked.tsx
+++ b/src/components/Chart/Charts/LineStacked.tsx
@@ -334,16 +334,18 @@ export const LineStackedChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
+              role="none"
               data-tooltip={true}
               tabIndex={-1}
               styles={visuallyHidden}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >
-              <p>{item}</p>
-              <span>
-                {getText(t.locale, set.label)}: {set.data[itemKey]}
-              </span>
+              {`${getText(t.locale, set.label)} ${
+                data.labels && Array.isArray(data.labels)
+                  ? getText(t.locale, data.labels[itemKey])
+                  : getText(t.locale, data.labels)
+              }: ${set.data[itemKey]}`}
             </Box>
           ))
         )

--- a/src/components/Chart/Charts/LineStacked.tsx
+++ b/src/components/Chart/Charts/LineStacked.tsx
@@ -161,6 +161,12 @@ export const LineStackedChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -192,6 +198,7 @@ export const LineStackedChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -334,10 +341,9 @@ export const LineStackedChart = ({
           (set.data as number[]).map((item: number, itemKey: number) => (
             // Generated tooltips for screen readers
             <Box
-              role="none"
               data-tooltip={true}
               tabIndex={-1}
-              styles={visuallyHidden}
+              styles={{ ...visuallyHidden, display: "none" }}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
             >

--- a/src/components/Chart/Charts/Pie.tsx
+++ b/src/components/Chart/Charts/Pie.tsx
@@ -159,6 +159,12 @@ export const PieChart = ({
     function removeDataPointsHoverStates() {
       const datasetMeta = meta();
       if (selectedIndex > -1 && datasetMeta.data[selectedIndex]) {
+        const tooltipAnnoucement = document.getElementById(
+          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+        );
+        if (tooltipAnnoucement) {
+          tooltipAnnoucement.style.setProperty("display", "none");
+        }
         datasetMeta.controller.removeHoverStyle(
           datasetMeta.data[selectedIndex],
           0,
@@ -190,6 +196,7 @@ export const PieChart = ({
         `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
       );
       if (tooltipAnnoucement) {
+        tooltipAnnoucement.style.setProperty("display", "block");
         tooltipAnnoucement.focus();
       }
     }
@@ -322,7 +329,7 @@ export const PieChart = ({
               tabIndex={-1}
               key={itemKey}
               id={`${chartId}-tooltip-${setKey}-${itemKey}`}
-              styles={visuallyHidden}
+              styles={{ ...visuallyHidden, display: "none" }}
             >
               {`${getText(t.locale, set.label)} ${
                 data.labels && Array.isArray(data.labels)

--- a/src/components/Chart/Charts/Pie.tsx
+++ b/src/components/Chart/Charts/Pie.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
+import get from "lodash/get";
 import Chart from "chart.js";
 import { SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { TeamsTheme } from "../../../themes";
@@ -32,13 +33,11 @@ export const PieChart = ({
     );
   }
   const { colorScheme, theme, colors, t } = siteVariables;
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
-  const chartRef = React.useRef<Chart | undefined>();
-  const chartId = React.useMemo(
-    () => Math.random().toString(36).substr(2, 9),
-    []
-  );
-  const chartDataPointColors = React.useMemo(
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<Chart | undefined>();
+  const chartId = useMemo(() => Math.random().toString(36).substr(2, 9), []);
+  const chartDataPointColors = useMemo(
     () => [
       colorScheme.brand.backgroundFocus2,
       colorScheme.brand.foreground3,
@@ -93,7 +92,7 @@ export const PieChart = ({
     let selectedIndex = -1;
     let selectedDataSet = 0;
 
-    if (!canvasRef.current) return;
+    if (!(canvasRef.current && containerRef.current)) return;
     const ctx = canvasRef.current.getContext("2d");
     if (!ctx) return;
     const config: any = chartConfig({ type: "pie" });
@@ -185,14 +184,18 @@ export const PieChart = ({
         index: selectedIndex,
         siteVariables,
       });
-      document
-        .getElementById(
-          `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
-        )
-        ?.focus();
+      const tooltipAnnoucement = document.getElementById(
+        `${chartId}-tooltip-${selectedDataSet}-${selectedIndex}`
+      );
+      if (tooltipAnnoucement) {
+        tooltipAnnoucement.focus();
+      }
     }
 
-    function resetChartStates() {
+    function resetChartStates(e: FocusEvent) {
+      if (get(e, ["relatedTarget", "dataset", "tooltip"], false)) {
+        return;
+      }
       removeDataPointsHoverStates();
       const activeElements = chart.tooltip._active;
       const requestedElem =
@@ -248,15 +251,18 @@ export const PieChart = ({
       showFocusedDataPoint();
     }
 
-    canvasRef.current.addEventListener("click", removeFocusStyleOnClick);
-    canvasRef.current.addEventListener("keydown", changeFocus);
-    canvasRef.current.addEventListener("focusout", resetChartStates);
+    containerRef.current.addEventListener("click", removeFocusStyleOnClick);
+    containerRef.current.addEventListener("keyup", changeFocus);
+    containerRef.current.addEventListener("focusout", resetChartStates);
     return () => {
       if (!chartRef.current) return;
-      if (canvasRef.current) {
-        canvasRef.current.removeEventListener("click", removeFocusStyleOnClick);
-        canvasRef.current.removeEventListener("keydown", changeFocus);
-        canvasRef.current.removeEventListener("focusout", resetChartStates);
+      if (containerRef.current) {
+        containerRef.current.removeEventListener(
+          "click",
+          removeFocusStyleOnClick
+        );
+        containerRef.current.removeEventListener("keyup", changeFocus);
+        containerRef.current.removeEventListener("focusout", resetChartStates);
       }
       chartRef.current.destroy();
     };
@@ -297,35 +303,14 @@ export const PieChart = ({
     <ChartContainer
       siteVariables={siteVariables}
       data={data}
+      chartId={chartId}
+      chartLabel={title}
+      canvasRef={canvasRef}
+      containerRef={containerRef}
       chartDataPointColors={chartDataPointColors}
       patterns={chartBarDataPointPatterns}
       onLegendClick={onLegendClick}
       verticalDataAlignment
-    >
-      <canvas
-        id={chartId}
-        ref={canvasRef}
-        tabIndex={0}
-        style={{
-          userSelect: "none",
-        }}
-        aria-label={title}
-      >
-        {data.datasets.map((set, setKey) =>
-          (set.data as number[]).forEach((item: number, itemKey: number) => (
-            // Generated tooltips for screen readers
-            <div key={itemKey} id={`${chartId}-tooltip-${setKey}-${itemKey}`}>
-              <p>{item}</p>
-              <span>
-                {data.labels && Array.isArray(data.labels)
-                  ? getText(t.locale, data.labels[setKey])
-                  : getText(t.locale, data.labels)}
-                : {set.data[itemKey]}
-              </span>
-            </div>
-          ))
-        )}
-      </canvas>
-    </ChartContainer>
+    />
   );
 };

--- a/src/components/Chart/Charts/Pie.tsx
+++ b/src/components/Chart/Charts/Pie.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import get from "lodash/get";
 import Chart from "chart.js";
-import { SiteVariablesPrepared } from "@fluentui/react-northstar";
+import { Box, SiteVariablesPrepared } from "@fluentui/react-northstar";
 import { TeamsTheme } from "../../../themes";
 import { IChartData } from "../ChartTypes";
 import {
@@ -14,6 +13,9 @@ import {
 import { ChartContainer } from "./ChartContainer";
 import { buildPattern, chartBarDataPointPatterns } from "../ChartPatterns";
 import { getText } from "../../../translations";
+import { visuallyHidden } from "../../../lib/visuallyHidden";
+import get from "lodash/get";
+import flatten from "lodash/flatten";
 
 export const PieChart = ({
   title,
@@ -311,6 +313,26 @@ export const PieChart = ({
       patterns={chartBarDataPointPatterns}
       onLegendClick={onLegendClick}
       verticalDataAlignment
+      tooltipAnnouncements={flatten(
+        data.datasets.map((set, setKey) =>
+          (set.data as number[]).map((item: number, itemKey: number) => (
+            // Generated tooltips for screen readers
+            <Box
+              data-tooltip={true}
+              tabIndex={-1}
+              key={itemKey}
+              id={`${chartId}-tooltip-${setKey}-${itemKey}`}
+              styles={visuallyHidden}
+            >
+              {`${getText(t.locale, set.label)} ${
+                data.labels && Array.isArray(data.labels)
+                  ? getText(t.locale, data.labels[itemKey])
+                  : getText(t.locale, data.labels)
+              }: ${set.data[itemKey]}`}
+            </Box>
+          ))
+        )
+      )}
     />
   );
 };

--- a/src/lib/visuallyHidden.ts
+++ b/src/lib/visuallyHidden.ts
@@ -1,0 +1,11 @@
+export const visuallyHidden = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  margin: "-1px",
+  border: "0",
+  padding: "0",
+  overflow: "hidden",
+  clip: "rect(0 0 0 0)",
+  "clip-path": "inset(100%)",
+};


### PR DESCRIPTION
This PR adds tooltips which can be read-out by screen readers and puts focus on them as the tooltip within the chart canvas changes.

Developers don't need to change any props to benefit from this PR.

![Screen Recording 2022-06-01 at 15 20 55 mov](https://user-images.githubusercontent.com/855039/171520731-41f0f071-f609-46c5-abe7-e4a2a8308736.gif)