### PR TITLE
Add preventDefault into onClick handler of custom row actions (Table)

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -796,6 +796,9 @@ export const Table = (props: ITableProps) => {
                                                         onClick: (
                                                           e: SyntheticEvent<HTMLElement>
                                                         ) => {
+                                                          // Selecting an action from the dropdown with Enter key would let the Enter's default action
+                                                          // to submit a next focused element after this onClick. preventDefault() cancels the default action.
+                                                          e.preventDefault();
                                                           e.stopPropagation();
                                                           props.onInteraction!({
                                                             event: "click",


### PR DESCRIPTION
When using keyboard to navigate to "More options" (custom actions) of Table component, selecting an action with Enter key would also trigger Enter's default action (submit). Calling `preventDefault()` on the event will cancel the default action, while not affecting any functionality, as `onClick` was already handled at that point. 